### PR TITLE
Update azuredeployopenai.json

### DIFF
--- a/azuredeployopenai.json
+++ b/azuredeployopenai.json
@@ -52,6 +52,7 @@
       "kind": "OpenAI",
       "sku": { "name": "S0" },
       "properties": {
+        "customSubDomainName": "[toLower(parameters('accountName'))]",
         "publicNetworkAccess": "[parameters('publicNetworkAccess')]"
       }
     },


### PR DESCRIPTION
Custom DNS Name eingefügt, damit eine Einzigartige Azure OpenAI-Endpunkt URL rauskommt. Ansonsten gehts nicht mehr, da sonst immer der RZ Standort genutzt wird und GWC jetzt schon vergeben ist.